### PR TITLE
Update ext.php

### DIFF
--- a/ext.php
+++ b/ext.php
@@ -9,17 +9,14 @@
 
 namespace imkingdavid\prefixed;
 
-/**
- * @ignore
- */
-if (!defined('IN_PHPBB'))
-{
-	exit;
-}
-
-/**
- * Main extension class for Prefixed extension.
- */
+ /**
+* Extension class for custom enable/disable/purge actions
+*/
 class ext extends \phpbb\extension\base
 {
+	public function is_enableable()
+	{
+		$config = $this->container->get('config');
+		return version_compare($config['version'], '3.1.4', '>=') && version_compare(PHP_VERSION, '5.4.*', '>'));
+	}
 }


### PR DESCRIPTION
Since PHP 5.4 is required for this extension to work we are enforcing it.
The extension will be not installed if the minimum requirements are not met.

The check for IN_PHPBB is not required here.
