### PR TITLE
Update prefixed_module.php

### DIFF
--- a/acp/prefixed_module.php
+++ b/acp/prefixed_module.php
@@ -46,7 +46,6 @@ class prefixed_module
 
 		switch ($mode)
 		{
-			default:
 			case 'prefixes':
 				$page_title = 'ACP_PREFIXED_MANAGE';
 				// @todo Do this


### PR DESCRIPTION
PHP 7: Switch statements may only contain one default clause